### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "base64-img": "^1.0.4",
     "cucumber": "^5.1.0",
     "eslint": "^4.19.1",
-    "npm": "^6.0.0",
     "testcafe": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION

Hello PacoBZ!

It seems like you have npm as one of your (dev-) dependency in cucumber-testcafe.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
